### PR TITLE
[Bug Fix] Fixed spell check workflow naming

### DIFF
--- a/.github/workflows/spell-check.yaml
+++ b/.github/workflows/spell-check.yaml
@@ -1,5 +1,5 @@
 # yaml-language-server: $schema=https://json.schemastore.org/github-workflow.json
-name: Lint
+name: Spell Check
 on:
   workflow_call:
     inputs:


### PR DESCRIPTION
* Fixed the spell check workflow having the wrong name ("Lint" instead of "Spell Check").